### PR TITLE
Convert use of Core to Core_kernel

### DIFF
--- a/OMakefile
+++ b/OMakefile
@@ -10,7 +10,7 @@ if $(defined-env CAPNP_DEV)
 
 
 OCAMLPACKS[] =  \
-  core          \
+  core_kernel   \
   uint          \
   res           \
   ocplib-endian \

--- a/opam
+++ b/opam
@@ -1,0 +1,17 @@
+opam-version: "1"
+maintainer: "pelzlpj@gmail.com"
+build: [
+  ["env" "PREFIX=%{prefix}%" "omake"]
+  ["env" "PREFIX=%{prefix}%" "omake" "install"]
+]
+remove: [["env" "PREFIX=%{prefix}%" "omake" "uninstall"]]
+depends: [
+  "omake"
+  "ocamlfind" {>= "1.5.1"}
+  "core_kernel"
+  "ocplib-endian" {>= "0.7"}
+  "res"
+  "uint"
+  "camlp4"
+]
+ocaml-version: [>= "4.01.0"]

--- a/opam
+++ b/opam
@@ -1,4 +1,7 @@
-opam-version: "1"
+opam-version: "1.2"
+homepage: "https://github.com/pelzlpj/capnp-ocaml"
+bug-reports: "https://github.com/pelzlpj/capnp-ocaml/issues"
+dev-repo: "https://github.com/pelzlpj/capnp-ocaml.git"
 maintainer: "pelzlpj@gmail.com"
 build: [
   ["env" "PREFIX=%{prefix}%" "omake"]

--- a/src/benchmark/capnpCatrank.ml
+++ b/src/benchmark/capnpCatrank.ml
@@ -6,7 +6,7 @@ module CR :
   INCLUDE "catrank_defun.ml"
 end
 
-open Core.Std
+open Core_kernel.Std
 
 module TestCase = struct
   type request_reader_t   = CR.Reader.SearchResultList.t

--- a/src/benchmark/capnpEval.ml
+++ b/src/benchmark/capnpEval.ml
@@ -6,7 +6,7 @@ module E :
   INCLUDE "eval_defun.ml"
 end
 
-open Core.Std
+open Core_kernel.Std
 
 module TestCase = struct
   type request_reader_t   = E.Reader.Expression.t

--- a/src/benchmark/main.ml
+++ b/src/benchmark/main.ml
@@ -1,5 +1,5 @@
 
-open Core.Std
+open Core_kernel.Std
 
 let printf = Printf.printf
 let fprintf = Printf.fprintf

--- a/src/benchmark/methods.ml
+++ b/src/benchmark/methods.ml
@@ -1,5 +1,5 @@
 
-open Core.Std
+open Core_kernel.Std
 module IO = Capnp.IO
 module Codecs = Capnp.Codecs
 

--- a/src/compiler/c2b2b.ml
+++ b/src/compiler/c2b2b.ml
@@ -70,7 +70,7 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
        reading from truncated structs both lead to default data being returned. *)
 
 
-    open Core.Std
+    open Core_kernel.Std
 
     let sizeof_uint64 = 8
 
@@ -106,7 +106,7 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
       
       (* Runtime support which is common to both Reader and Builder interfaces. *)
       
-      open Core.Std
+      open Core_kernel.Std
       
       
       let sizeof_uint32 = 4
@@ -1760,7 +1760,7 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
        pointer will cause struct storage to be immediately allocated if that pointer
        was null). *)
 
-    open Core.Std
+    open Core_kernel.Std
 
     type ro = Message.ro
     type rw = Message.rw
@@ -1806,7 +1806,7 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
       
       (* Runtime support which is common to both Reader and Builder interfaces. *)
       
-      open Core.Std
+      open Core_kernel.Std
       
       
       let sizeof_uint32 = 4

--- a/src/compiler/defaults.ml
+++ b/src/compiler/defaults.ml
@@ -53,7 +53,7 @@
 *)
 
 
-open Core.Std
+open Core_kernel.Std
 
 module Copier = Capnp.Runtime.BuilderOps.Make(GenCommon.M)(GenCommon.M)
 module M = GenCommon.M

--- a/src/compiler/genCommon.ml
+++ b/src/compiler/genCommon.ml
@@ -28,7 +28,7 @@
  ******************************************************************************)
 
 
-open Core.Std
+open Core_kernel.Std
 
 module M   = Capnp.BytesMessage
 module PS_ = PluginSchema.Make(M)

--- a/src/compiler/genModules.ml
+++ b/src/compiler/genModules.ml
@@ -28,7 +28,7 @@
  ******************************************************************************)
 
 
-open Core.Std
+open Core_kernel.Std
 
 module PS        = GenCommon.PS
 module Context   = GenCommon.Context

--- a/src/compiler/genSignatures.ml
+++ b/src/compiler/genSignatures.ml
@@ -28,7 +28,7 @@
  ******************************************************************************)
 
 
-open Core.Std
+open Core_kernel.Std
 
 module PS      = GenCommon.PS
 module Context = GenCommon.Context

--- a/src/compiler/generate.ml
+++ b/src/compiler/generate.ml
@@ -28,7 +28,7 @@
  ******************************************************************************)
 
 
-open Core.Std
+open Core_kernel.Std
 
 module PS   = GenCommon.PS
 module C    = Capnp

--- a/src/compiler/main.ml
+++ b/src/compiler/main.ml
@@ -28,7 +28,7 @@
  ******************************************************************************)
 
 
-open Core.Std
+open Core_kernel.Std
 open Capnp
 
 module M  = BytesMessage

--- a/src/compiler/pluginSchema.ml
+++ b/src/compiler/pluginSchema.ml
@@ -1045,7 +1045,7 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
        reading from truncated structs both lead to default data being returned. *)
 
 
-    open Core.Std
+    open Core_kernel.Std
 
     let sizeof_uint64 = 8
 
@@ -1081,7 +1081,7 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
       
       (* Runtime support which is common to both Reader and Builder interfaces. *)
       
-      open Core.Std
+      open Core_kernel.Std
       
       
       let sizeof_uint32 = 4
@@ -2735,7 +2735,7 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
        pointer will cause struct storage to be immediately allocated if that pointer
        was null). *)
 
-    open Core.Std
+    open Core_kernel.Std
 
     type ro = Message.ro
     type rw = Message.rw
@@ -2781,7 +2781,7 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
       
       (* Runtime support which is common to both Reader and Builder interfaces. *)
       
-      open Core.Std
+      open Core_kernel.Std
       
       
       let sizeof_uint32 = 4

--- a/src/compiler/topsort.ml
+++ b/src/compiler/topsort.ml
@@ -28,7 +28,7 @@
  ******************************************************************************)
 
 
-open Core.Std
+open Core_kernel.Std
 
 module PS = GenCommon.PS
 module C  = Capnp

--- a/src/runtime/META
+++ b/src/runtime/META
@@ -1,6 +1,6 @@
 description = "Runtime support library for capnp-ocaml"
 version = "2.0.1"
-requires = "core uint res ocplib-endian camlp4.macro"
+requires = "core_kernel uint res ocplib-endian camlp4.macro"
 archive(byte) = "libcapnp.cma"
 archive(byte, plugin) = "libcapnp.cma"
 archive(native) = "libcapnp.cmxa"

--- a/src/runtime/builder-inc.ml
+++ b/src/runtime/builder-inc.ml
@@ -34,7 +34,7 @@
    pointer will cause struct storage to be immediately allocated if that pointer
    was null). *)
 
-open Core.Std
+open Core_kernel.Std
 
 type ro = Message.ro
 type rw = Message.rw

--- a/src/runtime/bytesStorage.ml
+++ b/src/runtime/bytesStorage.ml
@@ -28,7 +28,7 @@
  ******************************************************************************)
 
 
-open Core.Std
+open Core_kernel.Std
 open EndianBytes
 
 type t = Bytes.t

--- a/src/runtime/cArray.ml
+++ b/src/runtime/cArray.ml
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************)
 
-open Core.Std
+open Core_kernel.Std
 
 type ro = Message.ro
 type rw = Message.rw
@@ -162,7 +162,7 @@ let to_list a =
   List.init (length a) ~f:(fun i -> get a i)
 
 let to_array a =
-  Core.Std.Array.init (length a) (fun i -> get a i)
+  Core_kernel.Std.Array.init (length a) (fun i -> get a i)
 
 let set_list a lst =
   let () = init a (List.length lst) in
@@ -173,7 +173,7 @@ let set_array a arr =
   Array.iteri arr ~f:(fun i x -> set a i x)
 
 let map_array a ~f =
-  Core.Std.Array.init (length a) (fun i -> f (get a i))
+  Core_kernel.Std.Array.init (length a) (fun i -> f (get a i))
 
 let map_list a ~f =
   List.init (length a) ~f:(fun i -> f (get a i))

--- a/src/runtime/codecs.ml
+++ b/src/runtime/codecs.ml
@@ -28,7 +28,7 @@
  ******************************************************************************)
 
 
-open Core.Std
+open Core_kernel.Std
 
 
 type compression_t = [ `None | `Packing ]

--- a/src/runtime/codecs.mli
+++ b/src/runtime/codecs.mli
@@ -69,7 +69,7 @@ module FramedStream : sig
       A successful decode removes the data from the stream and returns the
       frame data in the form of a BytesMessage. *)
   val get_next_frame : t ->
-    (Message.rw Message.BytesMessage.Message.t, FramingError.t) Core.Std.Result.t
+    (Message.rw Message.BytesMessage.Message.t, FramingError.t) Core_kernel.Std.Result.t
 end
 
 

--- a/src/runtime/codecsSig.ml
+++ b/src/runtime/codecsSig.ml
@@ -64,6 +64,6 @@ module type DECODER = sig
       frame as a [string list] with one list element for every segment within
       the message. *)
   val get_next_frame : t ->
-    (Message.rw Message.BytesMessage.Message.t, FramingError.t) Core.Std.Result.t
+    (Message.rw Message.BytesMessage.Message.t, FramingError.t) Core_kernel.Std.Result.t
 end
 

--- a/src/runtime/common-inc.ml
+++ b/src/runtime/common-inc.ml
@@ -29,7 +29,7 @@
 
 (* Runtime support which is common to both Reader and Builder interfaces. *)
 
-open Core.Std
+open Core_kernel.Std
 
 
 let sizeof_uint32 = 4

--- a/src/runtime/farPointer.ml
+++ b/src/runtime/farPointer.ml
@@ -28,8 +28,8 @@
  ******************************************************************************)
 
 
-module Int64 = Core.Core_int64
-module Caml  = Core.Caml
+module Int64 = Core_kernel.Core_int64
+module Caml  = Core_kernel.Caml
 
 type landing_pad_t =
   | NormalPointer

--- a/src/runtime/fragmentBuffer.ml
+++ b/src/runtime/fragmentBuffer.ml
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************)
 
-open Core.Std
+open Core_kernel.Std
 
 
 type t = {

--- a/src/runtime/iO.ml
+++ b/src/runtime/iO.ml
@@ -104,7 +104,7 @@ module WriteContext = struct
 
 end
 
-let rec select fd ?(restart = true) =
+let rec select ?(restart = true) fd =
   try
     select fd ~restart
   with Unix.Unix_error (Unix.EINTR, _, _) ->

--- a/src/runtime/listPointer.ml
+++ b/src/runtime/listPointer.ml
@@ -1,6 +1,6 @@
 
-module Int64 = Core.Core_int64;;
-module Caml  = Core.Caml
+module Int64 = Core_kernel.Core_int64;;
+module Caml  = Core_kernel.Caml
 
 type element_type_t =
   | Void

--- a/src/runtime/message.ml
+++ b/src/runtime/message.ml
@@ -28,7 +28,7 @@
  ******************************************************************************)
 
 
-open Core.Std
+open Core_kernel.Std
 
 type ro = MessageSig.ro
 type rw = MessageSig.rw

--- a/src/runtime/otherPointer.ml
+++ b/src/runtime/otherPointer.ml
@@ -28,8 +28,8 @@
  ******************************************************************************)
 
 
-module Int64 = Core.Core_int64
-module Caml  = Core.Caml
+module Int64 = Core_kernel.Core_int64
+module Caml  = Core_kernel.Caml
 
 type t =
   | Capability of Uint32.t

--- a/src/runtime/packing.ml
+++ b/src/runtime/packing.ml
@@ -28,7 +28,7 @@
  ******************************************************************************)
 
 
-open Core.Std
+open Core_kernel.Std
 
 let count_zeros ~start ~stop s =
   let sum = ref 0 in

--- a/src/runtime/reader-inc.ml
+++ b/src/runtime/reader-inc.ml
@@ -32,7 +32,7 @@
    reading from truncated structs both lead to default data being returned. *)
 
 
-open Core.Std
+open Core_kernel.Std
 
 let sizeof_uint64 = 8
 

--- a/src/runtime/structPointer.ml
+++ b/src/runtime/structPointer.ml
@@ -28,8 +28,8 @@
  ******************************************************************************)
 
 
-module Int64 = Core.Core_int64
-module Caml  = Core.Caml
+module Int64 = Core_kernel.Core_int64
+module Caml  = Core_kernel.Caml
 
 type t = {
   (** Signed offset in words from end of the pointer to start of struct

--- a/src/runtime/util.ml
+++ b/src/runtime/util.ml
@@ -28,7 +28,7 @@
  ******************************************************************************)
 
 
-open Core.Std
+open Core_kernel.Std
 
 exception Out_of_int_range of string
 let out_of_int_range s = raise (Out_of_int_range s)
@@ -75,7 +75,7 @@ let round_up_mult_8 (x : int) : int =
    This variant parallels the behavior of Python's slicing operator. *)
 let str_slice ?(start : int option) ?(stop : int option) (s : string)
   : string =
-  let norm s i = Core.Ordered_collection_common.normalize
+  let norm s i = Core_kernel.Ordered_collection_common.normalize
       ~length_fun:String.length s i
   in
   let real_start =

--- a/src/tests/testCodecs.ml
+++ b/src/tests/testCodecs.ml
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************)
 
-open Core.Std
+open Core_kernel.Std
 open OUnit2
 module Quickcheck = Core_extended.Quickcheck
 

--- a/src/tests/testEncoding.ml
+++ b/src/tests/testEncoding.ml
@@ -29,7 +29,7 @@
 
 (* Inspired by encoding-test.c++, as found in the capnproto source. *)
 
-open Core.Std
+open Core_kernel.Std
 
 module BM  = Capnp.BytesMessage
 module T   = Test.Make(BM)


### PR DESCRIPTION
By using `Unix` functions insted of `Core.Unix`, we can allow `capnp-ocaml` to be theoretically portable to windows once `opam` suppoert is improved there.