### PR TITLE
Run unit-tests with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: c
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-docker.sh
+script: bash -ex .travis-docker.sh
+sudo: required
+services:
+  - docker
+env:
+  global:
+  - OPAMERRLOGLEN=0
+  - PACKAGE=capnp
+  matrix:
+  - DISTRO=debian-9 OCAML_VERSION=4.04.0

--- a/opam
+++ b/opam
@@ -7,6 +7,10 @@ dev-repo: "https://github.com/pelzlpj/capnp-ocaml.git"
 author: "Paul Pelzl <pelzlpj@gmail.com>"
 maintainer: "Paul Pelzl <pelzlpj@gmail.com>"
 build: [["env" "PREFIX=%{prefix}%" "omake"]]
+build-test: [
+  ["env" "PREFIX=%{prefix}%" "omake" "src/tests/run-tests"]
+  [ocaml "./src/tests/run-tests.run"]
+]
 install: [["env" "PREFIX=%{prefix}%" "omake" "install"]]
 remove: [["env" "PREFIX=%{prefix}%" "omake" "uninstall"]]
 depends: [
@@ -18,5 +22,9 @@ depends: [
   "res"
   "uint"
   "camlp4"
+  "core_extended" {test}
+]
+depexts: [
+  [["debian"] ["capnproto"]]
 ]
 available: [ ocaml-version >= "4.01.0" ]

--- a/src/compiler/defaults.ml
+++ b/src/compiler/defaults.ml
@@ -177,9 +177,9 @@ let emit_instantiate_builder_structs struct_array : string list =
     let open M.StructStorage in [
       "let " ^ (builder_string_of_ident ident) ^ " =";
       "  let data_segment_id = " ^
-        (Int.to_string struct_storage.data.M.Slice.segment_id) ^ "in";
+        (Int.to_string struct_storage.data.M.Slice.segment_id) ^ " in";
       "  let pointers_segment_id = " ^
-        (Int.to_string struct_storage.pointers.M.Slice.segment_id) ^ "in {";
+        (Int.to_string struct_storage.pointers.M.Slice.segment_id) ^ " in {";
       "  DefaultsMessage_.StructStorage.data = {";
       "    DefaultsMessage_.Slice.msg = _builder_defaults_message;";
       "    DefaultsMessage_.Slice.segment = DefaultsMessage_.Message.get_segment \


### PR DESCRIPTION
To make the tests pass, I also:

- Added a missing space in the code generation.
- Added a depext on capnp.
- Added core_extended to the test dependencies.

(before before merging this PR, you should enable tests on this repository at https://travis-ci.org/ -> Accounts, otherwise it won't be active until the next change)

Sample output: https://travis-ci.org/talex5/capnp-ocaml/builds/226759579