### PR TITLE
Add missing support for pointers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ src/benchmark/c2b2b_defun.ml
 src/benchmark/carsales_defun.ml
 src/benchmark/catrank_defun.ml
 src/benchmark/eval_defun.ml
+oUnit*.cache
+oUnit*.log

--- a/.merlin
+++ b/.merlin
@@ -1,4 +1,4 @@
-S src
+S src/**
 B _build/src
 PKG uint
 PKG core

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: c
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-docker.sh
+script: bash -ex .travis-docker.sh
+sudo: required
+services:
+  - docker
+env:
+  global:
+  - OPAMERRLOGLEN=0
+  - PACKAGE=capnp
+  matrix:
+  - DISTRO=debian-9 OCAML_VERSION=4.04.0

--- a/opam
+++ b/opam
@@ -7,6 +7,10 @@ dev-repo: "https://github.com/pelzlpj/capnp-ocaml.git"
 author: "Paul Pelzl <pelzlpj@gmail.com>"
 maintainer: "Paul Pelzl <pelzlpj@gmail.com>"
 build: [["env" "PREFIX=%{prefix}%" "omake"]]
+build-test: [
+  ["env" "PREFIX=%{prefix}%" "omake" "src/tests/run-tests"]
+  [ocaml "./src/tests/run-tests.run"]
+]
 install: [["env" "PREFIX=%{prefix}%" "omake" "install"]]
 remove: [["env" "PREFIX=%{prefix}%" "omake" "uninstall"]]
 depends: [
@@ -18,5 +22,9 @@ depends: [
   "res"
   "uint"
   "camlp4"
+  "core_extended" {test}
+]
+depexts: [
+  [["debian"] ["capnproto"]]
 ]
 available: [ ocaml-version >= "4.01.0" ]

--- a/src/compiler/defaults.ml
+++ b/src/compiler/defaults.ml
@@ -177,9 +177,9 @@ let emit_instantiate_builder_structs struct_array : string list =
     let open M.StructStorage in [
       "let " ^ (builder_string_of_ident ident) ^ " =";
       "  let data_segment_id = " ^
-        (Int.to_string struct_storage.data.M.Slice.segment_id) ^ "in";
+        (Int.to_string struct_storage.data.M.Slice.segment_id) ^ " in";
       "  let pointers_segment_id = " ^
-        (Int.to_string struct_storage.pointers.M.Slice.segment_id) ^ "in {";
+        (Int.to_string struct_storage.pointers.M.Slice.segment_id) ^ " in {";
       "  DefaultsMessage_.StructStorage.data = {";
       "    DefaultsMessage_.Slice.msg = _builder_defaults_message;";
       "    DefaultsMessage_.Slice.segment = DefaultsMessage_.Message.get_segment \

--- a/src/compiler/genModules.ml
+++ b/src/compiler/genModules.ml
@@ -1222,10 +1222,18 @@ let generate_one_field_accessors ~context ~node_id ~scope
                 (if mode = Mode.Reader then reader_default_str
                  else builder_default_str)
                 field_ofs;
+              "let " ^ field_name ^ "_get_interface x =";
+              sprintf "  %s.get_interface x %u"
+                api_module
+                field_ofs;
             ] in
             let setters = [
               "let " ^ field_name ^ "_set x v =";
               sprintf "  BA_.set_pointer %sx %u v"
+                discr_str
+                field_ofs;
+              "let " ^ field_name ^ "_set_interface x v =";
+              sprintf "  BA_.set_interface %sx %u v"
                 discr_str
                 field_ofs;
             ] in
@@ -1536,6 +1544,7 @@ let rec generate_struct_node ~context ~scope ~nested_modules ~mode
     | Mode.Reader -> [
         "let of_message x = RA_.get_root_struct (RA_.Message.readonly x)";
         "let of_builder x = Some (RA_.StructStorage.readonly x)";
+        "let of_pointer = RA_.deref_opt_struct_pointer";
       ]
     | Mode.Builder ->
         let data_words    = PS.Node.Struct.data_word_count_get struct_def in
@@ -1548,6 +1557,10 @@ let rec generate_struct_node ~context ~scope ~nested_modules ~mode
           "let init_root ?message_size () =";
           sprintf "  BA_.alloc_root_struct ?message_size \
                    ~data_words:%u ~pointer_words:%u ()"
+            data_words pointer_words;
+          "let init_pointer ptr =";
+          sprintf "  BA_.init_struct_pointer ptr \
+                   ~data_words:%u ~pointer_words:%u"
             data_words pointer_words;
         ]
   in

--- a/src/compiler/genSignatures.ml
+++ b/src/compiler/genSignatures.ml
@@ -149,12 +149,16 @@ let generate_one_field_accessors ~context ~scope ~mode field
           Getter [
             sprintf "val %s_get : t -> %s"
               field_name
-              (GenCommon.type_name ~context ~mode ~scope_mode:mode scope tp); ];
+              (GenCommon.type_name ~context ~mode ~scope_mode:mode scope tp);
+            sprintf "val %s_get_interface : t -> Uint32.t option"
+              field_name ];
           Setter [
             sprintf "val %s_set : t -> %s -> %s"
               field_name
               (GenCommon.type_name ~context ~mode ~scope_mode:mode scope tp)
-              (GenCommon.type_name ~context ~mode ~scope_mode:mode scope tp); ];
+              (GenCommon.type_name ~context ~mode ~scope_mode:mode scope tp);
+            sprintf "val %s_set_interface : t -> Uint32.t option -> unit"
+              field_name ];
         ]
       | List list_descr ->
           let list_type = List.element_type_get list_descr in [
@@ -319,12 +323,14 @@ let generate_struct_node ~context ~scope ~nested_modules
     | Mode.Reader -> [
         "val of_message : 'cap message_t -> t";
         "val of_builder : builder_t -> t";
+        "val of_pointer : pointer_t -> t";
       ]
     | Mode.Builder -> [
         "val of_message : rw message_t -> t";
         "val to_message : t -> rw message_t";
         "val to_reader : t -> reader_t";
         "val init_root : ?message_size:int -> unit -> t";
+        "val init_pointer : pointer_t -> t";
       ]
   in
   header @

--- a/src/runtime/builder-inc.ml
+++ b/src/runtime/builder-inc.ml
@@ -1308,6 +1308,18 @@ let init_struct
   let () = BOps.init_struct_pointer pointer_bytes storage in
   storage
 
+let init_struct_pointer
+    pointer_bytes
+    ~(data_words : int)
+    ~(pointer_words : int)
+  : rw NM.StructStorage.t =
+  let () = BOps.deep_zero_pointer pointer_bytes in
+  let storage =
+    BOps.alloc_struct_storage pointer_bytes.NM.Slice.msg ~data_words ~pointer_words
+  in
+  let () = BOps.init_struct_pointer pointer_bytes storage in
+  storage
+
 (* Locate the storage region corresponding to the root struct of a message.
    The [data_words] and [pointer_words] specify the expected struct layout. *)
 let get_root_struct

--- a/src/runtime/reader-inc.ml
+++ b/src/runtime/reader-inc.ml
@@ -73,6 +73,11 @@ let deref_struct_pointer (pointer_bytes : 'cap Slice.t)
       invalid_msg "decoded capability pointer where struct pointer was expected"
 
 
+let deref_opt_struct_pointer = function
+  | None -> None
+  | Some x -> deref_struct_pointer x
+
+
 let void_list_decoders =
   ListDecoders.Empty (fun (x : unit) -> x)
 

--- a/src/tests/testEncoding.ml
+++ b/src/tests/testEncoding.ml
@@ -1626,6 +1626,20 @@ let test_int_accessors ctx =
   assert_raises_invalid_arg (fun () -> B.u_int64_field_set_int_exn root (-1))
 
 
+let test_any_pointers ctx =
+  let root  = T.Builder.TestAnyPointer.init_root () in
+  let ptr = T.Builder.TestAnyPointer.any_pointer_field_get root in
+  let child = T.Builder.TestSturdyRefHostId.init_pointer ptr in
+  T.Builder.TestSturdyRefHostId.host_set child "test-host";
+  let rroot = T.Reader.TestAnyPointer.of_builder root in
+  let rptr = T.Reader.TestAnyPointer.any_pointer_field_get rroot in
+  let rchild = T.Reader.TestSturdyRefHostId.of_pointer rptr in
+  assert_equal ~printer:(fun f -> f) (T.Reader.TestSturdyRefHostId.host_get rchild) "test-host";
+  (* Interfaces *)
+  T.Builder.TestAnyPointer.any_pointer_field_set_interface root (Some (Uint32.of_int 42));
+  let iface = T.Reader.TestAnyPointer.any_pointer_field_get_interface rroot in
+  assert_equal iface (Some (Uint32.of_int 42))
+
 
 let encoding_suite =
   "all_types" >::: [
@@ -1647,6 +1661,7 @@ let encoding_suite =
     "test constants" >:: test_constants;
     "test global constants" >:: test_global_constants;
     "test int accessors" >:: test_int_accessors;
+    "test any pointers" >:: test_any_pointers;
   ]
 
 let () = run_test_tt_main encoding_suite


### PR DESCRIPTION
Before, the only ways to create a struct were as a root, or as a child with a type declared in the schema. For AnyPointer types, we need to be able to add any struct to a message.

This commit adds two new auto-generated operations to structs:

- `Child.init_pointer ptr` allocates a fresh `Child` struct, storing a pointer to it in `ptr`, and returns its builder.

- `Child.of_pointer ptr` returns a reader for the `Child` struct pointed to by `ptr`.

Also, it is sometimes necessary to set an AnyPointer to an interface rather than to a struct. For this, there are two new generated operations on pointers: `field_set_interface` and `field_get_interface`.