### PR TITLE
Disable warnings in generated files and fix benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ src/benchmark/c2b2b_defun.ml
 src/benchmark/carsales_defun.ml
 src/benchmark/catrank_defun.ml
 src/benchmark/eval_defun.ml
+oUnit*.cache
+oUnit*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,6 @@ env:
   - OPAMERRLOGLEN=0
   - PACKAGE=capnp
   matrix:
+  - DISTRO=debian-9 OCAML_VERSION=4.02.3
+  - DISTRO=debian-9 OCAML_VERSION=4.03.0
   - DISTRO=debian-9 OCAML_VERSION=4.04.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: c
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-docker.sh
+script: bash -ex .travis-docker.sh
+sudo: required
+services:
+  - docker
+env:
+  global:
+  - OPAMERRLOGLEN=0
+  - PACKAGE=capnp
+  matrix:
+  - DISTRO=debian-9 OCAML_VERSION=4.04.0

--- a/OMakefile
+++ b/OMakefile
@@ -1,6 +1,5 @@
 USE_OCAMLFIND = true
 
-OCAMLFINDFLAGS += -syntax camlp4o
 OCAMLOPTFLAGS += -inline 1000
 OCAMLFLAGS = -thread -short-paths
 

--- a/opam
+++ b/opam
@@ -7,6 +7,10 @@ dev-repo: "https://github.com/pelzlpj/capnp-ocaml.git"
 author: "Paul Pelzl <pelzlpj@gmail.com>"
 maintainer: "Paul Pelzl <pelzlpj@gmail.com>"
 build: [["env" "PREFIX=%{prefix}%" "omake"]]
+build-test: [
+  ["env" "PREFIX=%{prefix}%" "omake" "src/tests/run-tests"]
+  [ocaml "./src/tests/run-tests.run"]
+]
 install: [["env" "PREFIX=%{prefix}%" "omake" "install"]]
 remove: [["env" "PREFIX=%{prefix}%" "omake" "uninstall"]]
 depends: [
@@ -18,5 +22,9 @@ depends: [
   "res"
   "uint"
   "camlp4"
+  "core_extended" {test}
+]
+depexts: [
+  [["debian"] ["capnproto"]]
 ]
 available: [ ocaml-version >= "4.01.0" ]

--- a/opam
+++ b/opam
@@ -27,4 +27,4 @@ depends: [
 depexts: [
   [["debian"] ["capnproto"]]
 ]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.02.0" ]

--- a/src/benchmark/OMakefile
+++ b/src/benchmark/OMakefile
@@ -51,7 +51,8 @@ $(GENERATED): $(COMPILER) .capnp-repo
 
 
 open build/C
-CFLAGS += -O3
+CFLAGS += -O3 -I$(shell $(OCAMLC) -where)
+
 StaticCLibrary(libfastrand, fast_rand)
 
 

--- a/src/benchmark/OMakefile
+++ b/src/benchmark/OMakefile
@@ -3,6 +3,18 @@ OCAML_LIBS += ../runtime/libcapnp
 OCAML_CLIBS = libfastrand
 OCAMLPACKS += core
 
+Camlp4o(module) =
+    section
+        OCAMLFINDFLAGS += -syntax camlp4o
+        $(module).cmi:
+        $(module).cmo:
+        $(module).o:
+        $(module).cmx:
+
+Camlp4o(capnpCarsales)
+Camlp4o(capnpCatrank)
+Camlp4o(capnpEval)
+
 GENERATED = \
   c2b2b.mli \
   c2b2b.ml \

--- a/src/compiler/defaults.ml
+++ b/src/compiler/defaults.ml
@@ -177,9 +177,9 @@ let emit_instantiate_builder_structs struct_array : string list =
     let open M.StructStorage in [
       "let " ^ (builder_string_of_ident ident) ^ " =";
       "  let data_segment_id = " ^
-        (Int.to_string struct_storage.data.M.Slice.segment_id) ^ "in";
+        (Int.to_string struct_storage.data.M.Slice.segment_id) ^ " in";
       "  let pointers_segment_id = " ^
-        (Int.to_string struct_storage.pointers.M.Slice.segment_id) ^ "in {";
+        (Int.to_string struct_storage.pointers.M.Slice.segment_id) ^ " in {";
       "  DefaultsMessage_.StructStorage.data = {";
       "    DefaultsMessage_.Slice.msg = _builder_defaults_message;";
       "    DefaultsMessage_.Slice.segment = DefaultsMessage_.Message.get_segment \

--- a/src/compiler/generate.ml
+++ b/src/compiler/generate.ml
@@ -38,6 +38,7 @@ module Mode    = GenCommon.Mode
 
 
 let sig_s_header ~context = [
+  "[@@@ocaml.warning \"-27-32-37-60\"]";
   "type ro = Capnp.Message.ro";
   "type rw = Capnp.Message.rw";
   "";

--- a/src/runtime/OMakefile
+++ b/src/runtime/OMakefile
@@ -1,3 +1,4 @@
+OCAMLFINDFLAGS += -syntax camlp4o
 
 RUNTIME_MODULES =   \
   builderOps        \


### PR DESCRIPTION
There's nothing that users of the files can do about the warnings, so disable them. Example warnings:

    Warning 32: unused value has_call.
    Warning 27: unused variable x.
    Warning 37: constructor Struct is never used to build values.
    Warning 60: unused module DefaultsCopier_.

This requires PPX and doesn't work with camlp4. I've therefore upped the minimum OCaml version to 4.02 and disabled camlp4 for the files that don't need it (which includes all the autogenerated ones).

Note that the tests already didn't work on 4.01:

    # File "testCodecs.ml", line 35, characters 20-55:
    # Error: Unbound module Core_extended.Quickcheck_deprecated

This also includes a fix for building the benchmarks (couldn't find OCaml headers) and adds Travis tests for 4.02 and 4.03.